### PR TITLE
add optional init_pool/1 callback

### DIFF
--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -30,7 +30,7 @@ defmodule NimblePool do
 
   Receives the `pool_state` as an argument and must return `{:ok, pool_state}`
   upon successful initialization, `:ignore` to exit normally, or `{:stop, reason}`
-  to exit with `reason`, returning `{:error, reason}`.
+  to exit with `reason` and return `{:error, reason}`.
 
   This is a good place to perform any registration or special pool_state initialization.
 

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -134,6 +134,7 @@ defmodule NimblePoolTest do
         terminate: fn reason, [] -> send(parent, {:terminate, reason}) end
       )
 
+    assert {:messages, [:init_pool | _]} = Process.info(self(), :messages)
     assert_receive :init_pool
 
     assert NimblePool.checkout!(pool, :checkout, fn :client_state_out ->

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -4,13 +4,11 @@ defmodule NimblePoolTest do
   defmodule StatelessPool do
     @behaviour NimblePool
 
-    def init_pool(pool_state) do
-      {init_pool, pool_state} = pop_in(pool_state.arg[:init_pool])
-
-      if is_function(init_pool) do
-        init_pool.(pool_state)
+    def init_pool({_worker, arg, _pool_size} = init_args) do
+      if is_function(arg[:init_pool]) do
+        arg[:init_pool].(init_args)
       else
-        {:ok, pool_state}
+        :ok
       end
     end
 
@@ -126,9 +124,9 @@ defmodule NimblePoolTest do
 
     pool =
       stateless_pool!(
-        init_pool: fn next ->
+        init_pool: fn _ ->
           send(parent, :init_pool)
-          {:ok, next}
+          :ok
         end,
         init: fn next -> {:ok, next} end,
         handle_checkout: fn :checkout, _from, next -> {:ok, :client_state_out, next} end,


### PR DESCRIPTION
While using NimblePool, I had the need to register my pools in a Registry. 

My first attempt led me to call `Registry.register/3` in the `NimblePool.init/1` callback, but this is actually for the workers and not the pool itself.

This pr adds an optional `init_pool/1` callback to the `NimblePool` behaviour where one is now able to perform a registration if needed, or customize the pool state itself.