### PR TITLE
create CI using GitHub Actions, adding recommended Elixir and Erlang/OTP combinations 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        warnings_as_errors: [false]
         include:
           - elixir: 1.7.4
             otp: 19.3.6.13
-            warnings_as_errors: false
           - elixir: 1.8.2
             otp: 20.3.8.26
-            warnings_as_errors: false
           - elixir: 1.9.4
             otp: 20.3.8.26
             warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.4
             otp: 21.3.8.16
-            warnings_as_errors: false
           - elixir: 1.10.4
             otp: 23.0.3
-            warnings_as_errors: false
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
             otp: 21.3.8.16
           - elixir: 1.10.4
             otp: 23.0.3
+            check_formatted: true
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
+      - run: mix format --check-formatted
+        if: matrix.check_formatted
       - name: Install Dependencies
         run: |
           mix local.hex --force
@@ -38,14 +41,3 @@ jobs:
       - run: mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
       - run: mix test
-
-  check_formatted:
-    name: Check formatted
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.2
-      - uses: actions/setup-elixir@v1.4.0
-        with:
-          otp-version: 23.0.3
-          elixir-version: 1.10.4
-      - run: mix format --check-formatted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        warnings_as_errors: [false]
         include:
           - elixir: 1.7.4
             otp: 19.3.6.13
+            warnings_as_errors: false
           - elixir: 1.8.2
             otp: 20.3.8.26
+            warnings_as_errors: false
           - elixir: 1.9.4
             otp: 20.3.8.26
             warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.4
             otp: 21.3.8.16
+            warnings_as_errors: false
           - elixir: 1.10.4
             otp: 23.0.3
+            warnings_as_errors: false
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,19 @@ jobs:
         include:
           - elixir: 1.7.4
             otp: 19.3.6.13
+            warnings_as_errors: false
           - elixir: 1.8.2
             otp: 20.3.8.26
+            warnings_as_errors: false
           - elixir: 1.9.4
             otp: 20.3.8.26
+            warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.4
             otp: 21.3.8.16
+            warnings_as_errors: false
           - elixir: 1.10.4
             otp: 23.0.3
+            warnings_as_errors: false
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0
@@ -34,6 +39,8 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get --only test
+      - run: mix compile --warnings-as-errors
+        if: matrix.warnings_as_errors
       - run: mix test
 
   check_formatted:
@@ -46,20 +53,3 @@ jobs:
           otp-version: 23.0.3
           elixir-version: 1.10.4
       - run: mix format --check-formatted
-
-  compile_without_warnings:
-    name: Compile without warnings
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.2
-      - uses: actions/setup-elixir@v1.4.0
-        with:
-          otp-version: 22.3.4.5
-          elixir-version: 1.9.4 # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
-      - name: Install Dependencies
-        run: |
-          mix local.hex --force
-          mix local.rebar --force
-          mix deps.get
-      - name: Compile without warnings
-        run: mix compile --warnings-as-errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,13 @@ jobs:
         include:
           - elixir: 1.7.4
             otp: 19.3.6.13
-            warnings_as_errors: false
           - elixir: 1.8.2
             otp: 20.3.8.26
-            warnings_as_errors: false
           - elixir: 1.9.4
             otp: 20.3.8.26
             warnings_as_errors: true # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
           - elixir: 1.10.4
             otp: 21.3.8.16
-            warnings_as_errors: false
           - elixir: 1.10.4
             otp: 23.0.3
             warnings_as_errors: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
             otp: 21.3.8.16
           - elixir: 1.10.4
             otp: 23.0.3
-            warnings_as_errors: false
     steps:
       - uses: actions/checkout@v2.3.2
       - uses: actions/setup-elixir@v1.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,6 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get --only test
-      - run: mix compile --warnings-as-errors
+      - run: MIX_ENV=test mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
       - run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     name: mix test (Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - elixir: 1.7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  mix_test:
+    name: mix test (Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - elixir: 1.7.4
+            otp: 19.3.6.13
+          - elixir: 1.8.2
+            otp: 20.3.8.26
+          - elixir: 1.9.4
+            otp: 20.3.8.26
+          - elixir: 1.10.4
+            otp: 21.3.8.16
+          - elixir: 1.10.4
+            otp: 23.0.3
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-elixir@v1.4.0
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Install Dependencies
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only test
+      - run: mix test
+
+  check_formatted:
+    name: Check formatted
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-elixir@v1.4.0
+        with:
+          otp-version: 23.0.3
+          elixir-version: 1.10.4
+      - run: mix format --check-formatted
+
+  compile_without_warnings:
+    name: Compile without warnings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.2
+      - uses: actions/setup-elixir@v1.4.0
+        with:
+          otp-version: 22.3.4.5
+          elixir-version: 1.9.4 # not 1.10 as its --warnigs-as-errors has bugs https://github.com/elixir-lang/elixir/issues/10073
+      - name: Install Dependencies
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get
+      - name: Compile without warnings
+        run: mix compile --warnings-as-errors

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -4,10 +4,10 @@ defmodule NimblePoolTest do
   defmodule StatelessPool do
     @behaviour NimblePool
 
-    def init_pool([init_pool: fun] ++ rest), do: fun.(rest)
+    def init_pool([{:init_pool, fun} | rest]), do: fun.(rest)
     def init_pool(rest), do: {:ok, rest}
 
-    def init_worker([init_worker: fun] ++ rest = pool_state) do
+    def init_worker([{:init_worker, fun} | rest] = pool_state) do
       Tuple.append(fun.(rest), pool_state)
     end
 


### PR DESCRIPTION
This pull request creates the CI workflow on GitHub Actions, making sure all recommended Elixir and Erlang/OTP combinations are run.

Quoting José Valim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.