### PR TITLE
Ensure lazy pool can't start more workers than config allows

### DIFF
--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -612,7 +612,7 @@ defmodule NimblePool do
   defp init_worker_if_lazy_and_empty(%{lazy: nil} = state), do: state
 
   defp init_worker_if_lazy_and_empty(%{lazy: lazy, resources: resources} = state) do
-    if :queue.is_empty(resources) do
+    if lazy > 0 and :queue.is_empty(resources) do
       %{async: async, worker: worker, state: pool_state} = state
       {pool_state, resources, async} = init_worker(worker, pool_state, resources, async)
       %{state | async: async, resources: resources, state: pool_state, lazy: lazy - 1}


### PR DESCRIPTION
We use lazy pools in Finch and recently someone pointed out that they
were seeing more connections opened than their configuration should have
allowed. Original issue here: https://github.com/keathley/finch/issues/115

Previously a lazy NimblePool would always init a new worker if there were none available. This change adds check to make sure we have not hit the max pool size already. 