### PR TITLE
Terminate idle resources

### DIFF
--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -871,8 +871,7 @@ defmodule NimblePool do
 
   defp get_metadata() do
     %{
-      enqueued_at: System.monotonic_time(:millisecond),
-      idle_hits: 0
+      enqueued_at: System.monotonic_time(:millisecond)
     }
   end
 end

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -198,7 +198,16 @@ defmodule NimblePool do
 
     * If you are terminating workers with `handle_ping/2`, the last worker may be terminated after up to
       `worker_idle_timeout + worker_idle_timeout * ceil(number_of_workers/max_idle_pings)`
-       instead of `2 * worker_idle_timeout - 1` milliseconds of idle time.
+       instead of `2 * worker_idle_timeout` milliseconds of idle time.
+
+      For instance if you have a pool with 10 workers and a ping of 1 second and:
+
+      Considering a negligible worker termination time and a worst case scenario where all the workers
+      goes idle right after an verification cycle is started.
+
+      Without `max_idle_ping` the last work will be terminated in the next cycle, 2 seconds.
+
+      With a `max_idle_ping` of 2, the last worker will be terminated only in the 5th cycle, 6 seconds.
 
   ## Disclaimers
 

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -187,6 +187,18 @@ defmodule NimblePool do
         will be called for every worker on the pool.
 
     This callback is optional.
+
+  ## Disclaimers:
+
+  * On lazy pools, if no worker is currently on the pool the callback will never be called.
+  Therefore you can not rely on this callback to terminate empty lazy pools.
+
+  * On not lazy pools, if you return `{:remove, user_reason}` you may end up
+  terminating and initializing workers at the same time every idle verification cycle.
+
+  * On large pools, if many resources goes idle at the same cycle you may end up terminating a large
+  number of workers sequencially, what could lead to the pool being unable to fulfill requests.
+
   """
   @doc callback: :worker
   @callback handle_ping(

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -273,14 +273,14 @@ defmodule NimblePool do
     * `:lazy` - When `true`, workers are started lazily, only when necessary.
       Defaults to `false`.
 
-    * `:worker_idle_timeout` - Timeout to tag a worker as idle.
+    * `:worker_idle_timeout` - Timeout in milliseconds to tag a worker as idle.
       If not nil, starts a periodic timer on the same frequency that will ping
       all idle workers using `handle_ping/2` optional callback .
       Defaults to `nil`
 
     * `:max_idle_pings` - Defines a limit to the number of workers that can be pinged
       for each cycle of the `handle_ping/2` optional callback.
-      Defaults to `nil`, which is no limit. See `handle_ping/2` for more details.
+      Defaults to -1, which means limit. See `handle_ping/2` for more details.
   """
   def start_link(opts) do
     {{worker, arg}, opts} = Keyword.pop(opts, :worker)

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -276,11 +276,12 @@ defmodule NimblePool do
     * `:worker_idle_timeout` - Timeout in milliseconds to tag a worker as idle.
       If not nil, starts a periodic timer on the same frequency that will ping
       all idle workers using `handle_ping/2` optional callback .
-      Defaults to `nil`
+      Defaults to no timeout.
 
     * `:max_idle_pings` - Defines a limit to the number of workers that can be pinged
       for each cycle of the `handle_ping/2` optional callback.
-      Defaults to -1, which means limit. See `handle_ping/2` for more details.
+      Defaults to no limit. See `handle_ping/2` for more details.
+
   """
   def start_link(opts) do
     {{worker, arg}, opts} = Keyword.pop(opts, :worker)

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -15,6 +15,19 @@ defmodule NimblePool do
   @type client_state :: term
   @type user_reason :: term
 
+  @typedoc """
+  A map that holds metadata about the worker containing the following fields:
+
+    * enqueued_at: `System.monotonic_time(:millisecond)`. Updated whenever a worker is checked in
+
+    * idle_hits: Count how many times the resource was pinged due to idle timeout and did not get terminated.
+    Updated to 0 every check in.
+  """
+  @type worker_metadata :: %{
+          enqueued_at: integer(),
+          idle_hits: non_neg_integer()
+        }
+
   @doc """
   Initializes the worker.
 
@@ -170,12 +183,37 @@ defmodule NimblePool do
             ) ::
               {:ok, pool_state}
 
+  @doc """
+  Handle pings due to inactivity on worker
+
+  This callback is invoked with `worker_state`, `worker_metadata` and `pool_state`
+  whenever the idle worker periodic timer checks that a worker has been idle on the queue
+  for longer than `:resource_idle_timeout` pool configuration millisecond.
+
+  This callback must return some of the following values:
+    * `:terminate_worker`: The pool will proceed to the standard worker termination
+        defined in `terminate_worker/3` with reason `:idle_timenout`
+
+    * `:terminate_pool`: The entire pool process will be terminated, and `terminate_worker/3`
+        will be called for every worker available.
+
+    * `:nothing`: Just increase worker`s metadata idle hits by 1
+  """
+  @doc callback: :worker
+  @callback handle_ping(
+              worker_state,
+              worker_metadata,
+              pool_state
+            ) ::
+              :terminate_worker | :terminate_pool | :nothing
+
   @optional_callbacks init_pool: 1,
                       handle_checkin: 4,
                       handle_info: 2,
                       handle_enqueue: 2,
                       handle_update: 3,
-                      terminate_worker: 3
+                      terminate_worker: 3,
+                      handle_ping: 3
 
   @doc """
   Defines a pool to be started under the supervision tree.
@@ -213,6 +251,10 @@ defmodule NimblePool do
     * `:lazy` - When `true`, workers are started lazily, only when necessary.
       Defaults to `false`.
 
+    * `:resource_idle_timeout` - Time in milliseconds for worker inactivity validation.
+      If not nil, starts a periodic timer on the same frequency that will trigger idle workers validation.
+      Workers that were not checked out for longer than this will call `handle_ping/3`.
+      Defaults to `nil`
   """
   def start_link(opts) do
     {{worker, arg}, opts} = Keyword.pop(opts, :worker)

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -171,7 +171,7 @@ defmodule NimblePool do
               {:ok, pool_state}
 
   @doc """
-  Handle pings due to inactivity on worker
+  Handle pings due to inactivity on worker.
 
   Executed whenever the idle worker periodic timer verifies that a worker has been idle
   on the pool for longer than `:worker_idle_timeout` pool configuration milliseconds.
@@ -186,7 +186,7 @@ defmodule NimblePool do
     * `{:stop, user_reason}`: The entire pool process will be terminated, and `terminate_worker/3`
         will be called for every worker on the pool.
 
-    This callback is optional.
+  This callback is optional.
 
   ## Max idle pings
 
@@ -194,26 +194,23 @@ defmodule NimblePool do
   of workers. But it is important to keep in mind the following behaviours whenever utilizing it.
 
     * If you are not terminating workers with `handle_ping/2`, you may end up pinging only the same
-    workers over and over again because each cycle will ping only the first `:max_idle_pings` workers
+      workers over and over again because each cycle will ping only the first `:max_idle_pings` workers
 
     * If you are terminating workers with `handle_ping/2`, the last worker may be terminated after up to
-    `worker_idle_timeout + worker_idle_timeout * ceil(number_of_workers/max_idle_pings)`
-     instead of `2 * worker_idle_timeout - 1` milliseconds of idle time.
+      `worker_idle_timeout + worker_idle_timeout * ceil(number_of_workers/max_idle_pings)`
+       instead of `2 * worker_idle_timeout - 1` milliseconds of idle time.
 
   ## Disclaimers
 
     * On lazy pools, if no worker is currently on the pool the callback will never be called.
-    Therefore you can not rely on this callback to terminate empty lazy pools.
+      Therefore you can not rely on this callback to terminate empty lazy pools.
 
     * On not lazy pools, if you return `{:remove, user_reason}` you may end up
-    terminating and initializing workers at the same time every idle verification cycle.
+      terminating and initializing workers at the same time every idle verification cycle.
 
     * On large pools, if many resources goes idle at the same cycle you may end up terminating
-    a large number of workers sequencially, what could lead to the pool being unable to
-    fulfill requests. See `:max_idle_pings` option to prevent this.
-
-
-
+      a large number of workers sequentially, what could lead to the pool being unable to
+      fulfill requests. See `:max_idle_pings` option to prevent this.
 
   """
   @doc callback: :worker
@@ -273,8 +270,8 @@ defmodule NimblePool do
       Defaults to `nil`
 
     * `:max_idle_pings` - Defines a limit to the number of workers that can be pinged
-    for each cycle of the `handle_ping/2` optional callback.
-    Defaults to `nil`, which is no limit. See `handle_ping/2` for more details.
+      for each cycle of the `handle_ping/2` optional callback.
+      Defaults to `nil`, which is no limit. See `handle_ping/2` for more details.
   """
   def start_link(opts) do
     {{worker, arg}, opts} = Keyword.pop(opts, :worker)
@@ -408,7 +405,7 @@ defmodule NimblePool do
         Process.send_after(self(), :check_idle, worker_idle_timeout)
       else
         IO.warn(
-          "worker_idle_timeout is not nil but handle_ping/2 callback is not exported by the worker."
+          ":worker_idle_timeout was given but the worker does not export a handle_ping/2 callback"
         )
       end
     end

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -190,14 +190,14 @@ defmodule NimblePool do
 
   ## Disclaimers:
 
-  * On lazy pools, if no worker is currently on the pool the callback will never be called.
-  Therefore you can not rely on this callback to terminate empty lazy pools.
+    * On lazy pools, if no worker is currently on the pool the callback will never be called.
+    Therefore you can not rely on this callback to terminate empty lazy pools.
 
-  * On not lazy pools, if you return `{:remove, user_reason}` you may end up
-  terminating and initializing workers at the same time every idle verification cycle.
+    * On not lazy pools, if you return `{:remove, user_reason}` you may end up
+    terminating and initializing workers at the same time every idle verification cycle.
 
-  * On large pools, if many resources goes idle at the same cycle you may end up terminating a large
-  number of workers sequencially, what could lead to the pool being unable to fulfill requests.
+    * On large pools, if many resources goes idle at the same cycle you may end up terminating a large
+    number of workers sequencially, what could lead to the pool being unable to fulfill requests.
 
   """
   @doc callback: :worker
@@ -205,7 +205,7 @@ defmodule NimblePool do
               worker_state,
               pool_state
             ) ::
-              {:ok, worker_state} | {:remove, user_reason} | {:stop, user_reason()}
+              {:ok, worker_state} | {:remove, user_reason()} | {:stop, user_reason()}
 
   @optional_callbacks init_pool: 1,
                       handle_checkin: 4,

--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -533,7 +533,6 @@ defmodule NimblePool do
 
     case check_idle_resources(resources_list, now_in_ms, state) do
       {:ok, new_resources, new_state} ->
-        IO.puts("-- Finish cycle --")
         {:noreply, %{new_state | resources: new_resources}}
 
       {:stop, reason, state} ->
@@ -746,12 +745,12 @@ defmodule NimblePool do
       args = [worker_server_state, pool_state]
 
       case apply_worker_callback(worker, :handle_ping, args) do
+        {:ok, worker_state} ->
+          {:ok, worker_state}
+
         {:remove, user_reason} ->
           new_state = remove_worker(user_reason, worker_server_state, state)
           {:remove, new_state}
-
-        {:ok, worker_state} ->
-          {:ok, worker_state}
 
         {:stop, user_reason} ->
           {:stop, user_reason}

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -23,6 +23,10 @@ defmodule NimblePoolTest do
       next(instructions, :handle_info, &[message, &1])
     end
 
+    def handle_ping(instructions, pool_state) do
+      next(instructions, :handle_ping, &[&1, pool_state])
+    end
+
     def terminate_worker(reason, instructions, pool_state) do
       # We always allow skip ahead on terminate
       instructions = Enum.drop_while(instructions, &(elem(&1, 0) != :terminate_worker))
@@ -84,6 +88,10 @@ defmodule NimblePoolTest do
 
     def handle_info(message, worker_state) do
       TestAgent.next(worker_state, :handle_info, [message, worker_state])
+    end
+
+    def handle_ping(worker_state, pool_state) do
+      TestAgent.next(pool_state, :handle_ping, [worker_state, pool_state])
     end
 
     def terminate_worker(reason, worker_state, pid) do
@@ -1342,6 +1350,141 @@ defmodule NimblePoolTest do
 
       assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_command -> {:ok, :ok} end) ==
                :ok
+    end
+  end
+
+  describe "handle_ping" do
+    test "ping only idle workers" do
+      parent = self()
+
+      {_, pool} =
+        stateful_pool!(
+          [
+            init_worker: fn next -> {:ok, :worker1, next} end,
+            init_worker: fn next -> {:ok, :worker2, next} end,
+            init_worker: fn next -> {:ok, :worker3, next} end,
+            handle_checkout: fn :checkout, _from, worker_state, pool_state ->
+              {:ok, :client_state_out, worker_state, pool_state}
+            end,
+            handle_checkin: fn :client_state_in, _from, worker_state, pool_state ->
+              {:ok, worker_state, pool_state}
+            end,
+            handle_ping: fn worker, _pool_state ->
+              send(parent, {:ping, worker})
+              {:ok, worker}
+            end,
+            handle_ping: fn worker, _pool_state ->
+              send(parent, {:ping, worker})
+              {:ok, worker}
+            end,
+            terminate_worker: fn _reason, _, state -> {:ok, state} end,
+            terminate_worker: fn _reason, _, state -> {:ok, state} end,
+            terminate_worker: fn _reason, _, state -> {:ok, state} end
+          ],
+          pool_size: 3,
+          resource_idle_timeout: 4
+        )
+
+      :timer.sleep(2)
+
+      assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
+               {:result, :client_state_in}
+             end) == :result
+
+      :timer.sleep(3)
+
+      refute_received({:ping, :worker1})
+      assert_received({:ping, :worker2})
+      assert_received({:ping, :worker3})
+
+      NimblePool.stop(pool, :shutdown)
+    end
+
+    test "update worker state if handle_ping return {:ok, new_worker_state}" do
+      {_, pool} =
+        stateful_pool!(
+          [
+            init_worker: fn next -> {:ok, :worker1, next} end,
+            handle_ping: fn :worker1, _pool_state ->
+              {:ok, :new_worker_state}
+            end,
+            handle_checkout: fn :checkout, _from, worker_state, pool_state ->
+              assert worker_state == :new_worker_state
+              {:ok, :client_state_out, worker_state, pool_state}
+            end,
+            handle_checkin: fn :client_state_in, _from, :new_worker_state, pool_state ->
+              {:ok, :new_worker_state, pool_state}
+            end,
+            terminate_worker: fn _reason, _, state -> {:ok, state} end
+          ],
+          resource_idle_timeout: 1
+        )
+
+      :timer.sleep(2)
+
+      assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
+               {:result, :client_state_in}
+             end) == :result
+
+      NimblePool.stop(pool, :shutdown)
+    end
+
+    test "terminate worker if handle_ping return {:remove, user_reason}" do
+      parent = self()
+
+      pool =
+        stateless_pool!(
+          [
+            init_pool: fn next ->
+              {:ok, next}
+            end,
+            init_worker: fn next -> {:ok, next} end,
+            handle_ping: fn _next, _pool_state ->
+              {:remove, :some_reason}
+            end,
+            terminate_worker: fn reason, [], state ->
+              send(parent, {:terminate, reason})
+              {:ok, state}
+            end
+          ],
+          resource_idle_timeout: 1
+        )
+
+      Process.monitor(pool)
+
+      :timer.sleep(2)
+
+      assert_received {:terminate, :some_reason}
+      refute_received({:DOWN, _, :process, ^pool, {:shutdown, :some_reason}})
+    end
+
+    test "terminate pool if handle_ping return {:stop, reason}" do
+      parent = self()
+
+      pool =
+        stateless_pool!(
+          [
+            init_pool: fn next ->
+              {:ok, next}
+            end,
+            init_worker: fn next -> {:ok, next} end,
+            handle_ping: fn _next, _pool_state ->
+              {:stop, :some_reason}
+            end,
+            terminate_worker: fn reason, [], state ->
+              send(parent, {:terminate, reason})
+              {:ok, state}
+            end
+          ],
+          resource_idle_timeout: 1
+        )
+
+      Process.monitor(pool)
+
+      :timer.sleep(2)
+
+      assert_received {:terminate, {:shutdown, :some_reason}}
+      assert_received {:DOWN, _, :process, ^pool, {:shutdown, :some_reason}}
     end
   end
 end

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -1382,10 +1382,10 @@ defmodule NimblePoolTest do
             terminate_worker: fn _reason, _, state -> {:ok, state} end
           ],
           pool_size: 3,
-          resource_idle_timeout: 4
+          resource_idle_timeout: 5
         )
 
-      :timer.sleep(2)
+      :timer.sleep(3)
 
       assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
                {:result, :client_state_in}
@@ -1417,10 +1417,10 @@ defmodule NimblePoolTest do
             end,
             terminate_worker: fn _reason, _, state -> {:ok, state} end
           ],
-          resource_idle_timeout: 1
+          resource_idle_timeout: 5
         )
 
-      :timer.sleep(2)
+      :timer.sleep(6)
 
       assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
                {:result, :client_state_in}
@@ -1447,12 +1447,12 @@ defmodule NimblePoolTest do
               {:ok, state}
             end
           ],
-          resource_idle_timeout: 1
+          resource_idle_timeout: 5
         )
 
       Process.monitor(pool)
 
-      :timer.sleep(2)
+      :timer.sleep(6)
 
       assert_received {:terminate, :some_reason}
       refute_received({:DOWN, _, :process, ^pool, {:shutdown, :some_reason}})
@@ -1476,12 +1476,12 @@ defmodule NimblePoolTest do
               {:ok, state}
             end
           ],
-          resource_idle_timeout: 1
+          resource_idle_timeout: 5
         )
 
       Process.monitor(pool)
 
-      :timer.sleep(2)
+      :timer.sleep(6)
 
       assert_received {:terminate, {:shutdown, :some_reason}}
       assert_received {:DOWN, _, :process, ^pool, {:shutdown, :some_reason}}


### PR DESCRIPTION
https://github.com/dashbitco/nimble_pool/issues/1

Known problems with the implementantion:

  * On lazy pools, if no worker is currently on the pool the callback will never be called.
  Therefore you can not rely on this callback to terminate empty lazy pools.
  
  I'll make a follow up PR addressing this issue.

  * On not lazy pools, if you return `{:remove, user_reason}` you may end up
  terminating and initializing workers at the same time every idle verification cycle.
  
 I don't know exactly how to address this, probably will just add it to the docs. 

  * On large pools, if many resources goes idle at the same cycle you may end up terminating a large
  amount of workers sequencially, what could lead to the pool being unable to fulfill requests.
  
  I'll make a follow up PR addressing this issue, implementing something to stop the idle iterations earlier using some pool configuration probably. 
  