### PR TITLE
do not override previous resources on check idle verification

### DIFF
--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -790,7 +790,7 @@ defmodule NimblePool do
       {:empty, _} ->
         {:ok, new_resources, state}
 
-      {{:value, resource_data}, resources} ->
+      {{:value, resource_data}, next_resources} ->
         {worker_server_state, worker_metadata} = resource_data
         time_diff = now_in_ms - worker_metadata
 
@@ -801,7 +801,7 @@ defmodule NimblePool do
               new_resources = :queue.in(new_resource_data, new_resources)
 
               do_check_idle_resources(
-                resources,
+                next_resources,
                 now_in_ms,
                 state,
                 new_resources,
@@ -812,7 +812,7 @@ defmodule NimblePool do
               new_state = remove_worker(user_reason, worker_server_state, state)
 
               do_check_idle_resources(
-                resources,
+                next_resources,
                 now_in_ms,
                 new_state,
                 new_resources,

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -1604,18 +1604,15 @@ defmodule NimblePoolTest do
 
       Process.monitor(pool)
 
-      :timer.sleep(4)
-
       assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
+               :timer.sleep(1)
                {:result, :client_state_in}
              end) ==
                :result
 
-      :timer.sleep(15)
-
       assert_receive(:pong)
 
-      assert_received {:DOWN, _, :process, ^pool, {:shutdown, :some_reason}}
+      assert_receive {:DOWN, _, :process, ^pool, {:shutdown, :some_reason}}
     end
   end
 end

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -1605,7 +1605,7 @@ defmodule NimblePoolTest do
       Process.monitor(pool)
 
       assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
-               :timer.sleep(1)
+               Process.sleep(1)
                {:result, :client_state_in}
              end) ==
                :result

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -1577,5 +1577,45 @@ defmodule NimblePoolTest do
 
       NimblePool.stop(pool, :shutdown)
     end
+
+    test "Bug - Do not remove worker on verification cycle" do
+      parent = self()
+
+      {_, pool} =
+        stateful_pool!(
+          [
+            init_worker: fn next -> {:ok, :worker1, next} end,
+            handle_checkout: fn :checkout, _from, :worker1, pool_state ->
+              {:ok, :client_state_out, :worker1, pool_state}
+            end,
+            handle_checkin: fn :client_state_in, _from, :worker1, pool_state ->
+              {:ok, :worker1, pool_state}
+            end,
+            handle_ping: fn _next, _pool_state ->
+              send(parent, :pong)
+              {:stop, :some_reason}
+            end,
+            terminate_worker: fn _reason, _, state -> {:ok, state} end
+          ],
+          pool_size: 1,
+          lazy: true,
+          worker_idle_timeout: 5
+        )
+
+      Process.monitor(pool)
+
+      :timer.sleep(4)
+
+      assert NimblePool.checkout!(pool, :checkout, fn _ref, :client_state_out ->
+               {:result, :client_state_in}
+             end) ==
+               :result
+
+      :timer.sleep(15)
+
+      assert_receive(:pong)
+
+      assert_received {:DOWN, _, :process, ^pool, {:shutdown, :some_reason}}
+    end
   end
 end


### PR DESCRIPTION
The last non idle worker on resource list was being removed incorrectly from the list because of a variable name override.

It ultimately leads to an empty list of workers, that could lead to unexpected behaviours.

The added test simulate a scenario where the only worker would be removed from the resources when the verification cycle executed but the worker is not idle yet.

This led to an empty resources queue and finally the non termination of the pool because the pool has no workers to verify idle.