### PR TITLE
Bangify Code.ensure_loaded/1 function

### DIFF
--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -407,7 +407,7 @@ defmodule NimblePool do
   @impl true
   def init({worker, arg, pool_size, lazy, worker_idle_timeout, max_idle_pings}) do
     Process.flag(:trap_exit, true)
-    _ = Code.ensure_loaded(worker)
+    Code.ensure_loaded!(worker)
     lazy = if lazy, do: pool_size, else: nil
 
     if worker_idle_timeout do


### PR DESCRIPTION
This fix is important to avoid a crashloop in the pool when the option **:lazy** has been set to true.