### PR TITLE
feat: implement terminate_pool/2 callback

### DIFF
--- a/lib/nimble_pool.ex
+++ b/lib/nimble_pool.ex
@@ -283,8 +283,8 @@ defmodule NimblePool do
 
   The `reason` argmument is the same given to GenServer's terminate/2 callback.
 
-  No worker terminantion need to be done here because `terminate_worker/3` 
-  callback is already called for every worker before `terminate_pool/2`
+  It is not necessary to terminate workers here because the
+  `terminate_worker/3` callback has already been invoked.
 
   This should be used only for clean up extra resources that can not be
   handled by `terminate_worker/3` callback.

--- a/test/nimble_pool_test.exs
+++ b/test/nimble_pool_test.exs
@@ -67,7 +67,7 @@ defmodule NimblePoolTest do
           [{^instruction, return} | instructions] when is_function(return) ->
             {return, instructions}
 
-          # Always accept terminate_pool as a valida instruction when there is no more instructions
+          # Always accept terminate_pool as a valid instruction when there is no more instructions
           [] = state ->
             if instruction == :terminate_pool,
               do: {fn _, _ -> :ok end, []},


### PR DESCRIPTION
As mentioned on https://github.com/dashbitco/nimble_pool/issues/37, in order to implement pool telemetry features on nimble_pool clients would be nice to have some callback regarding pool termination. 

The implementation is very straight forward but I'm not sure if the changes that I made to the tests are the best approach. 

I had to always accept terminate_pool as a valid instruction.

The stateless is tricky, because this callback does not have access to worker state and therefore I need to work around this by introspecting into pool_state it self and if more complex use cases must be tested we gonna need another work around to update the remaining instructions. 

The stateful implementation I think is ok, because terminate_pool is valid only when there is no more instructions and also there is no need for a workaround on the worker state.

Let me know what you think! Thanks in advance! :smiley: 

