### PR TITLE
Change wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ defmodule PortPool do
   @doc ~S"""
   Executes a given command against a port kept by the pool.
 
-  First we start the port:
+  First we start the pool of ports:
 
       iex> child = {NimblePool, worker: {PortPool, :cat}, name: PortPool}
       iex> Supervisor.start_link([child], strategy: :one_for_one)
 
-  Now we can run commands against the pool of ports:
+  Now we can run commands against the ports of the pool:
 
       iex> PortPool.command(PortPool, "hello\n")
       "hello\n"
@@ -123,12 +123,12 @@ defmodule HTTP1Pool do
   @doc ~S"""
   Executes a given command against a connection kept by the pool.
 
-  First we start the connection:
+  First we start the pool:
 
       child = {NimblePool, worker: {HTTP1Pool, {:https, "elixir-lang.org", 443}}, name: HTTP1Pool}
       Supervisor.start_link([child], strategy: :one_for_one)
 
-  Then we can access it:
+  Then we can use the connections of the pool:
 
       iex> HTTP1Pool.get(HTTP1Pool, "/")
       {:ok, %{status: 200, ...}}

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ defmodule PortPool do
   @doc ~S"""
   Executes a given command against a port kept by the pool.
 
-  First we start the pool of ports:
+  First we start a pool of ports:
 
       iex> child = {NimblePool, worker: {PortPool, :cat}, name: PortPool}
       iex> Supervisor.start_link([child], strategy: :one_for_one)
 
-  Now we can run commands against the ports of the pool:
+  Now we can run commands against the ports in the pool:
 
       iex> PortPool.command(PortPool, "hello\n")
       "hello\n"
@@ -128,7 +128,7 @@ defmodule HTTP1Pool do
       child = {NimblePool, worker: {HTTP1Pool, {:https, "elixir-lang.org", 443}}, name: HTTP1Pool}
       Supervisor.start_link([child], strategy: :one_for_one)
 
-  Then we can use the connections of the pool:
+  Then we can use the connections in the pool:
 
       iex> HTTP1Pool.get(HTTP1Pool, "/")
       {:ok, %{status: 200, ...}}


### PR DESCRIPTION
In the README.md currently it says:

```
First we start the port:

      iex> child = {NimblePool, worker: {PortPool, :cat}, name: PortPool}
      iex> Supervisor.start_link([child], strategy: :one_for_one)
```

I believe this is confusing since what we are starting is a pool of ports synchronously not "the port".

In the following example in the README.md:

```
  First we start the connection:

      child = {NimblePool, worker: {HTTP1Pool, {:https, "elixir-lang.org", 443}}, name: HTTP1Pool}
      Supervisor.start_link([child], strategy: :one_for_one)
```

Here then below what it does it starts the pool which has :async worker initialization, so I think here also the
"the connection" should be changed.

This is why I opened this PR, I hope I'm not missing any details. Thanks for reviewing.